### PR TITLE
docs: remove private repo references (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 7 responsive grid configurations
 - Complete Tailwind CSS configuration and base CSS
 - Single-page and multi-page layout templates
-
-### Origin
-
-Design language extracted from two reference wireframe projects:
-- [sq-trade-complex-wireframe](https://github.com/qubernetic-org/sq-trade-complex-wireframe)
-- [sq-trade-simple-wireframe](https://github.com/qubernetic-org/sq-trade-simple-wireframe)

--- a/README.md
+++ b/README.md
@@ -107,13 +107,6 @@ The complete visual system is documented in [DESIGN-LANGUAGE.md](DESIGN-LANGUAGE
 | `CHANGELOG.md` | Version history ([Keep a Changelog](https://keepachangelog.com/) format) |
 | `CONTRIBUTING.md` | Contribution guidelines and design constraint checklist |
 
-## Origin
-
-Design language extracted from two wireframe reference projects:
-
-- [sq-trade-complex-wireframe](https://github.com/qubernetic-org/sq-trade-complex-wireframe) — multi-page wireframe
-- [sq-trade-simple-wireframe](https://github.com/qubernetic-org/sq-trade-simple-wireframe) — single-page wireframe
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## Summary

- Remove Origin section from README.md (referenced private repos)
- Remove Origin section from CHANGELOG.md

Closes #6