### PR TITLE
chore(release): prepare 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-03-18
+
+### Fixed
+
+- Remove private repository references from README and CHANGELOG (#6)
+
 ## [1.0.0] - 2026-03-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 7 responsive grid configurations
 - Complete Tailwind CSS configuration and base CSS
 - Single-page and multi-page layout templates
-
-### Origin
-
-Design language extracted from two reference wireframe projects:
-- [sq-trade-complex-wireframe](https://github.com/qubernetic-org/sq-trade-complex-wireframe)
-- [sq-trade-simple-wireframe](https://github.com/qubernetic-org/sq-trade-simple-wireframe)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Wireframe Mockup — Claude Code Skill
 
-[![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.0.1-blue.svg)](CHANGELOG.md)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-skill-7c3aed.svg)](https://claude.ai/code)
 [![React](https://img.shields.io/badge/React-TypeScript-61dafb.svg?logo=react&logoColor=white)](https://react.dev)

--- a/README.md
+++ b/README.md
@@ -107,13 +107,6 @@ The complete visual system is documented in [DESIGN-LANGUAGE.md](DESIGN-LANGUAGE
 | `CHANGELOG.md` | Version history ([Keep a Changelog](https://keepachangelog.com/) format) |
 | `CONTRIBUTING.md` | Contribution guidelines and design constraint checklist |
 
-## Origin
-
-Design language extracted from two wireframe reference projects:
-
-- [sq-trade-complex-wireframe](https://github.com/qubernetic-org/sq-trade-complex-wireframe) — multi-page wireframe
-- [sq-trade-simple-wireframe](https://github.com/qubernetic-org/sq-trade-simple-wireframe) — single-page wireframe
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: wireframe-mockup
 description: "Generate black-and-white structural wireframe mockups using a specific dashed-border, monospace, grayscale design system. Use when the user asks to create a wireframe, mockup, wireframe page, structural mockup, low-fidelity prototype, wireframe layout, or mentions 'wireframe', 'mockup', 'wireframe mockup', 'structural mockup'. Produces self-contained React + Tailwind CSS wireframe pages with placeholder images, dashed borders, and a diagonal watermark."
-version: 1.0.0
+version: 1.0.1
 license: MIT
 metadata:
   author: Qubernetic
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Wireframe Mockup Generator


### PR DESCRIPTION
## Summary

Patch release v1.0.1 — remove private repo references from documentation.

Closes #8